### PR TITLE
Add `zero?` conditional for real this time

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,0 @@
-[build]
-rustflags = ["-Clink-arg=-fuse-ld=lld", "-Ctarget-cpu=native"]


### PR DESCRIPTION
`zero?` will take 3 items off the stack, then if the first is zero (or not), it will push the second (resp. third) item back onto the stack.

```
~/tmp/drsm ∃ cargo run --release
   Compiling drsm v0.3.0 (/Users/graham/tmp/drsm)
    Finished `release` profile [optimized] target(s) in 6.07s
     Running `target/release/drsm`

    ____  ____  _____ __  ___
   / __ \/ __ \/ ___//  |/  /
  / / / / /_/ /\__ \/ /|_/ /
 / /_/ / _, _/___/ / /  / /
/_____/_/ |_|/____/_/  /_/

>  1 -1 0 zero?
env: zero? mod div mul sub add dup swap pop
stack: [ -1 ]
>  pop
env: zero? mod div mul sub add dup swap pop
stack: [ ]
>  1 -1 1729 zero?
env: zero? mod div mul sub add dup swap pop
stack: [ 1 ]
>
Bye!
```

I also neglected lexing negative numbers, which is embarrassing.