### PR TITLE
Hex

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ enum Token {
     Num(i64),
     #[regex(r"#[0-9a-fA-F]+", |lex| i64::from_str_radix(&lex.slice()[1..], 16).map_err(|e: ParseIntError| Error::Parsing(e.to_string())))]
     Hex(i64),
-    #[regex(r"\w+", |lex| lex.slice().to_owned())]
+    #[regex(r"\S+", |lex| lex.slice().to_owned())]
     Word(String),
 }
 


### PR DESCRIPTION
experimenting with adding hexadecimal numbers like `#abc123`. Adds a new token type `Hex`. Converts hex to `i64`. Adds a special hex display for hex numbers in the stack (until you do something with the number and then it displays as `Num`).  My editor would not let me keep line 3 the way it was and I am still trying to figure out what sets the formatter rules. 