### PR TITLE
Let's add some PBT!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,3 @@ panic = "abort"
 
 [dev-dependencies]
 proptest = "1.6.0"
-proptest-state-machine = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,5 @@ panic = "abort"
 
 [dev-dependencies]
 proptest = "1.6.0"
+proptest-derive = "0.5.1"
 proptest-state-machine = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,4 @@ panic = "abort"
 
 [dev-dependencies]
 proptest = "1.6.0"
-proptest-derive = "0.5.1"
 proptest-state-machine = "0.3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drsm"
 description = "Dylan's Rusty Stack Machine"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]
@@ -18,3 +18,7 @@ debug = 0
 lto = true
 codegen-units = 1
 panic = "abort"
+
+[dev-dependencies]
+proptest = "1.6.0"
+proptest-state-machine = "0.3.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,4 +38,7 @@ pub enum Error {
     /// `def` needs a body, but none was supplied.
     #[error("`def` needs a body, but none was supplied.")]
     DefBody,
+    /// `{0}` requires its second operand be nonzero
+    #[error("`{0}` requires its second operand be nonzero")]
+    NNZ(String),
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,3 @@
-
 use std::num::ParseIntError;
 
 /// Our Error type.

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,4 +1,3 @@
-#![allow(unsafe_code)]
 use crate::{error::Error, token::Token, word::Word};
 use indexmap::IndexMap;
 use logos::Logos;
@@ -56,30 +55,29 @@ impl Machine {
     pub fn read_eval(&mut self, s: &str) -> Result<(), Error> {
         let mut ts = Token::lexer(s).collect::<Result<Vec<_>, _>>()?.into_iter();
         while let Some(t) = ts.next() {
-            match t {
-                Token::Def => {
-                    let k = ts
-                        .next()
-                        .ok_or(Error::DefName)
-                        .and_then(Word::try_from)
-                        .and_then(Word::into_name)?;
-                    let us = ts.map(Word::try_from).collect::<Result<Vec<_>, _>>()?;
-                    if us.is_empty() {
-                        return Err(Error::DefBody);
-                    } else if us.iter().any(|u| u == &k) {
-                        return Err(Error::SelfRef(k));
-                    }
-                    let _ = self.env.insert(k, us);
-                    break;
+            if t == Token::Def {
+                let k = ts
+                    .next()
+                    .ok_or(Error::DefName)
+                    .and_then(Word::try_from)
+                    .and_then(Word::into_name)?;
+                let us = ts.map(Word::try_from).collect::<Result<Vec<_>, _>>()?;
+                if us.is_empty() {
+                    return Err(Error::DefBody);
+                } else if us.iter().any(|u| u == &k) {
+                    return Err(Error::SelfRef(k));
                 }
-                _ => self.eval(&Word::try_from(t)?)?,
+                let _ = self.env.insert(k, us);
+                break;  // no need for `else` here
             }
+            self.eval(&Word::try_from(t)?)?;
         }
         Ok(())
     }
     fn eval(&mut self, word: &Word) -> Result<(), Error> {
         check(&self.env, &self.stack, word)?;
-        eval_inner(&self.env, &mut self.stack, word)
+        eval_inner(&self.env, &mut self.stack, word);
+        Ok(())
     }
 }
 
@@ -103,179 +101,77 @@ fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Resul
 }
 
 /// Broken out to untangle mutability concerns.
-/// Full of **UNSAFE** code because this should only be called from within `Machine::eval`.
-fn eval_inner(
-    env: &IndexMap<String, Vec<Word>>,
-    stack: &mut Vec<i64>,
-    word: &Word,
-) -> Result<(), Error> {
-    let n = stack.len();
+/// Full of `stack.pop().expect(…)` because this should only be called from within `Machine::eval`.
+fn eval_inner(env: &IndexMap<String, Vec<Word>>, stack: &mut Vec<i64>, word: &Word) {
     match word {
-        Word::Pop => unsafe { stack.set_len(n - 1) },
-        Word::Swap => stack.swap(n - 1, n - 2),
-        Word::Dup => stack.push(unsafe { *stack.get_unchecked(n - 1) }),
-        Word::Add => unsafe {
-            *stack.get_unchecked_mut(n - 2) = stack
-                .get_unchecked(n - 1)
-                .wrapping_add(*stack.get_unchecked(n - 2));
-            stack.set_len(n - 1);
-        },
-        Word::Sub => unsafe {
-            *stack.get_unchecked_mut(n - 2) = stack
-                .get_unchecked(n - 1)
-                .wrapping_sub(*stack.get_unchecked(n - 2));
-            stack.set_len(n - 1);
-        },
-        Word::Mul => unsafe {
-            *stack.get_unchecked_mut(n - 2) = stack
-                .get_unchecked(n - 1)
-                .wrapping_mul(*stack.get_unchecked(n - 2));
-            stack.set_len(n - 1);
-        },
-        Word::Div => unsafe {
-            *stack.get_unchecked_mut(n - 2) = stack
-                .get_unchecked(n - 1)
-                .wrapping_div(*stack.get_unchecked(n - 2));
-            stack.set_len(n - 1);
-        },
-        Word::Mod => unsafe {
-            *stack.get_unchecked_mut(n - 2) = stack
-                .get_unchecked(n - 1)
-                .wrapping_rem(*stack.get_unchecked(n - 2));
-            stack.set_len(n - 1);
-        },
-        Word::Zero => unsafe {
-            if *stack.get_unchecked(n - 1) == 0 {
-                stack.swap(n - 2, n - 3);
-            }
-            stack.set_len(n - 2);
-        },
-        Word::Num(x) => {
-            stack.push(*x);
+        Word::Pop => {
+            stack.pop().expect("Internal error @ pop");
         }
+        Word::Swap => {
+            let x = stack.pop().expect("Internal error @ swap 1");
+            let y = stack.pop().expect("Internal error @ swap 2");
+            stack.push(x);
+            stack.push(y);
+        }
+        Word::Dup => {
+            let x = stack.pop().expect("Internal error @ dup");
+            stack.push(x);
+            stack.push(x);
+        }
+        Word::Add => {
+            let x = stack.pop().expect("Internal error @ add 1");
+            let y = stack.pop().expect("Internal error @ add 2");
+            stack.push(x.wrapping_add(y));
+        }
+        Word::Sub => {
+            let x = stack.pop().expect("Internal error @ sub 1");
+            let y = stack.pop().expect("Internal error @ sub 2");
+            stack.push(x.wrapping_sub(y));
+        }
+        Word::Mul => {
+            let x = stack.pop().expect("Internal error @ mul 1");
+            let y = stack.pop().expect("Internal error @ mul 2");
+            stack.push(x.wrapping_mul(y));
+        }
+        Word::Div => {
+            let x = stack.pop().expect("Internal error @ div 1");
+            let y = stack.pop().expect("Internal error @ div 2");
+            stack.push(x.wrapping_div(y));
+        }
+        Word::Mod => {
+            let x = stack.pop().expect("Internal error @ mod 1");
+            let y = stack.pop().expect("Internal error @ mod 2");
+            stack.push(x.wrapping_rem(y));
+        }
+        Word::Zero => {
+            let x = stack.pop().expect("Internal error at zero? 1");
+            let y = stack.pop().expect("Internal error at zero? 2");
+            let z = stack.pop().expect("Internal error at zero? 3");
+            stack.push(if x == 0 { y } else { z });
+        }
+        Word::Num(n) => stack.push(*n),
         Word::Custom(c) => {
             for v in &env[c] {
-                eval_inner(env, stack, v)?;
+                eval_inner(env, stack, v);
             }
         }
     }
-    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::{super::word::tests::word, *};
     use proptest::prelude::*;
-    use proptest_state_machine::{ReferenceStateMachine, StateMachineTest, prop_state_machine};
 
     proptest! {
         #[test]
-        fn check_implies_ok(ws in prop::collection::vec(word(), 1..512)) {
+        fn check_implies_ok(ws in prop::collection::vec(word(), 0..256)) {
             let mut m = Machine::default();
             for w in ws {
                 if check(&m.env, &m.stack, &w).is_ok() {
                     prop_assert!(m.eval(&w).is_ok(), "Machine with state {m:?} failed on {w}");
                 }
             }
-        }
-    }
-
-    prop_state_machine! {
-        #[test]
-        fn state_machine_testing(sequential 1..128 => Machine);
-    }
-
-    #[derive(Debug, Default, Clone)]
-    pub struct SafeMachine {
-        env: IndexMap<String, Vec<Word>>,
-        stack: Vec<i64>,
-    }
-
-    impl ReferenceStateMachine for SafeMachine {
-        type State = Self;
-        type Transition = Word;
-        fn init_state() -> BoxedStrategy<Self::State> {
-            Just(Self::default()).boxed()
-        }
-        fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
-            check(&state.env, &state.stack, transition).is_ok()
-        }
-        fn transitions(_: &Self::State) -> BoxedStrategy<Self::Transition> {
-            word().boxed()
-        }
-        fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
-            match transition {
-                Word::Pop => {
-                    state.stack.pop();
-                }
-                Word::Swap => {
-                    let x = state.stack.pop().expect("swap 1");
-                    let y = state.stack.pop().expect("swap 2");
-                    state.stack.push(x);
-                    state.stack.push(y);
-                }
-                Word::Dup => {
-                    let x = state.stack.last().copied().expect("dup");
-                    state.stack.push(x);
-                }
-                Word::Add => {
-                    let x = state.stack.pop().expect("add 1");
-                    let y = state.stack.pop().expect("add 2");
-                    state.stack.push(x.wrapping_add(y));
-                }
-                Word::Sub => {
-                    let x = state.stack.pop().expect("sub 1");
-                    let y = state.stack.pop().expect("sub 2");
-                    state.stack.push(x.wrapping_sub(y));
-                }
-                Word::Mul => {
-                    let x = state.stack.pop().expect("mul 1");
-                    let y = state.stack.pop().expect("mul 2");
-                    state.stack.push(x.wrapping_mul(y));
-                }
-                Word::Div => {
-                    let x = state.stack.pop().expect("div 1");
-                    let y = state.stack.pop().expect("div 2");
-                    state.stack.push(x.wrapping_div(y));
-                }
-                Word::Mod => {
-                    let x = state.stack.pop().expect("mod 1");
-                    let y = state.stack.pop().expect("mod 2");
-                    state.stack.push(x.wrapping_rem(y));
-                }
-                Word::Zero => {
-                    let x = state.stack.pop().expect("zero 1");
-                    let y = state.stack.pop().expect("zero 2");
-                    let z = state.stack.pop().expect("zero 3");
-                    state.stack.push(if x == 0 { y } else { z });
-                }
-                Word::Num(n) => state.stack.push(*n),
-                Word::Custom(c) => {
-                    for v in state.env.get(c).cloned().unwrap_or_default() {
-                        state = Self::apply(state, &v);
-                    }
-                }
-            }
-            state
-        }
-    }
-
-    impl StateMachineTest for Machine {
-        type SystemUnderTest = Self;
-        type Reference = SafeMachine;
-        fn init_test(_r: &<Self::Reference as ReferenceStateMachine>::State) -> Self {
-            Self::default()
-        }
-        fn apply(
-            mut sut: Self::SystemUnderTest,
-            r#ref: &<Self::Reference as ReferenceStateMachine>::State,
-            transition: <Self::Reference as ReferenceStateMachine>::Transition,
-        ) -> Self::SystemUnderTest {
-            sut.eval(&transition).unwrap_or_else(|e| panic!("{transition} errored: {e}"));
-            for (x, y) in sut.stack.iter().zip(r#ref.stack.iter()) {
-                assert_eq!(x, y, "Different values in stacks: sut={x}, ref={y}");
-            }
-            sut
         }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -90,27 +90,33 @@ impl Machine {
             Word::Add => {
                 let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
                 let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x + y));
+                self.stack.borrow_mut().push(Word::Num(x.wrapping_add(y)));
             }
             Word::Sub => {
                 let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
                 let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x - y));
+                self.stack.borrow_mut().push(Word::Num(x.wrapping_sub(y)));
             }
             Word::Mul => {
                 let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
                 let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x * y));
+                self.stack.borrow_mut().push(Word::Num(x.wrapping_mul(y)));
             }
             Word::Div => {
                 let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
                 let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x / y));
+                if y == 0 {
+                    return Err(Error::NNZ(w.to_string()));
+                }
+                self.stack.borrow_mut().push(Word::Num(x.wrapping_div(y)));
             }
             Word::Mod => {
                 let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
                 let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x % y));
+                if y == 0 {
+                    return Err(Error::NNZ(w.to_string()));
+                }
+                self.stack.borrow_mut().push(Word::Num(x.wrapping_rem(y)));
             }
             Word::Zero => {
                 let x = self.pop(w, 3, 0).and_then(i64::try_from)?;
@@ -129,5 +135,162 @@ impl Machine {
             },
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use proptest_state_machine::{ReferenceStateMachine, StateMachineTest, prop_state_machine};
+
+    prop_state_machine! {
+        #[test]
+        fn state_machine_testing(sequential 1..20 => Machine);
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    pub enum Op {
+        Push(i64),
+        Pop,
+        Swap,
+        Dup,
+        Add,
+        Sub,
+        Mul,
+        Div,
+        Mod,
+        Zero,
+        // NOTE: no Custom(w)
+    }
+
+    impl From<Op> for Word {
+        fn from(o: Op) -> Self {
+            match o {
+                Op::Push(n) => Self::Num(n),
+                Op::Pop => Self::Pop,
+                Op::Swap => Self::Swap,
+                Op::Dup => Self::Dup,
+                Op::Add => Self::Add,
+                Op::Sub => Self::Sub,
+                Op::Mul => Self::Mul,
+                Op::Div => Self::Div,
+                Op::Mod => Self::Mod,
+                Op::Zero => Self::Zero,
+            }
+        }
+    }
+
+    pub struct Dummy;
+    impl ReferenceStateMachine for Dummy {
+        type State = Vec<i64>;
+        type Transition = Op;
+        fn init_state() -> BoxedStrategy<Self::State> {
+            Just(Vec::new()).boxed()
+        }
+        fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
+            dbg!((&state, &transition));
+            match transition {
+                Op::Push(_) => true,
+                Op::Pop | Op::Dup => !state.is_empty(),
+                Op::Swap | Op::Add | Op::Sub | Op::Mul => state.len() > 1,
+                Op::Div | Op::Mod => {
+                    state.len() > 1 && state[state.len() - 1] > 0 && state[state.len() - 2] > 0
+                }
+                Op::Zero => state.len() > 2,
+            }
+        }
+        fn transitions(_: &Self::State) -> BoxedStrategy<Self::Transition> {
+            prop_oneof![
+                any::<i64>().prop_map(Op::Push),
+                Just(Op::Pop),
+                Just(Op::Swap),
+                Just(Op::Dup),
+                Just(Op::Add),
+                Just(Op::Sub),
+                Just(Op::Mul),
+                Just(Op::Div),
+                Just(Op::Mod),
+                Just(Op::Zero),
+            ]
+            .boxed()
+        }
+        fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
+            match transition {
+                Op::Push(n) => state.push(*n),
+                Op::Pop => {
+                    state.pop();
+                }
+                Op::Swap => {
+                    let x = state.pop().expect("swap 1");
+                    let y = state.pop().expect("swap 2");
+                    state.push(x);
+                    state.push(y);
+                }
+                Op::Dup => {
+                    let x = state.pop().expect("dup");
+                    state.push(x);
+                    state.push(x);
+                }
+                Op::Add => {
+                    let x = state.pop().expect("add 1");
+                    let y = state.pop().expect("add 2");
+                    state.push(x.wrapping_add(y));
+                }
+                Op::Sub => {
+                    let x = state.pop().expect("sub 1");
+                    let y = state.pop().expect("sub 2");
+                    state.push(x.wrapping_sub(y));
+                }
+                Op::Mul => {
+                    let x = state.pop().expect("mul 1");
+                    let y = state.pop().expect("mul 2");
+                    state.push(x.wrapping_mul(y));
+                }
+                Op::Div => {
+                    let x = state.pop().expect("div 1");
+                    let y = state.pop().expect("div 2");
+                    state.push(x.wrapping_div(y));
+                }
+                Op::Mod => {
+                    let x = state.pop().expect("mod 1");
+                    let y = state.pop().expect("mod 2");
+                    state.push(x.wrapping_rem(y));
+                }
+                Op::Zero => {
+                    let x = state.pop().expect("zero 1");
+                    let y = state.pop().expect("zero 2");
+                    let z = state.pop().expect("zero 3");
+                    state.push(if x == 0 { y } else { z });
+                }
+            }
+            state
+        }
+    }
+
+    impl StateMachineTest for Machine {
+        type SystemUnderTest = Self;
+        type Reference = Dummy;
+        fn init_test(_r: &<Self::Reference as ReferenceStateMachine>::State) -> Self {
+            Self::default()
+        }
+        fn apply(
+            sut: Self::SystemUnderTest,
+            r#ref: &<Self::Reference as ReferenceStateMachine>::State,
+            transition: <Self::Reference as ReferenceStateMachine>::Transition,
+        ) -> Self::SystemUnderTest {
+            let w = Word::from(transition);
+            sut.eval(&w).unwrap_or_else(|_| panic!("{w}"));
+            for (x, y) in sut.stack.borrow().iter().zip(r#ref.iter()) {
+                let n = i64::try_from(x.clone());
+                assert!(
+                    n.is_ok(),
+                    "We only push numbers, but trying to convert back yielded {n:?}"
+                );
+                let n = n.unwrap_or_default();
+                assert_eq!(n, *y, "Different values in stacks: sut={n}, ref={y}");
+            }
+            sut
+        }
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -163,7 +163,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn check_implies_ok(ws in prop::collection::vec(word(), 1..100)) {
+        fn check_implies_ok(ws in prop::collection::vec(word(), 1..200)) {
             let mut m = Machine::default();
             for w in ws {
                 if m.check(&w).is_ok() {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -144,14 +144,15 @@ impl Machine {
                 self.stack.borrow_mut().push(if x == 0 { y } else { z });
             }
             Word::Num(n) => self.stack.borrow_mut().push(*n),
-            Word::Custom(w) => match self.env.get(w) {
-                None => return Err(Error::Unknown(w.to_string())),
-                Some(vs) => {
-                    for v in vs {
-                        self.eval(v)?;
-                    }
+            Word::Custom(w) => {
+                for v in self
+                    .env
+                    .get(w)
+                    .ok_or_else(|| Error::Unknown(w.to_string()))?
+                {
+                    self.eval(v)?;
                 }
-            },
+            }
         }
         Ok(())
     }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -83,6 +83,7 @@ impl Machine {
     }
 }
 
+/// Broken out to untangle mutability concerns.
 fn eval_inner(
     env: &IndexMap<String, Vec<Word>>,
     stack: &mut Vec<i64>,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -75,53 +75,47 @@ impl Machine {
             Ok(())
         }
     }
-    fn pop(&self, w: &Word, required: usize, stack_len: usize) -> Result<i64, Error> {
-        self.stack
-            .borrow_mut()
-            .pop()
-            .ok_or_else(|| Error::Small(w.to_string(), required, stack_len))
-    }
     fn eval(&self, w: &Word) -> Result<(), Error> {
         match w {
             Word::Pop => {
                 self.check(w, 1)?;
-                self.pop(w, 1, 0).map(|_| ())?;
+                self.stack.borrow_mut().pop().expect("Internal error @ pop");
             }
             Word::Swap => {
                 self.check(w, 2)?;
-                let x = self.pop(w, 2, 0)?;
-                let y = self.pop(w, 2, 1)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error @ swap 1");
+                let y = self.stack.borrow_mut().pop().expect("Internal error @ swap 2");
                 self.stack.borrow_mut().push(x);
                 self.stack.borrow_mut().push(y);
             }
             Word::Dup => {
                 self.check(w, 1)?;
-                let x = self.pop(w, 1, 0)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error @ dup");
                 self.stack.borrow_mut().push(x);
                 self.stack.borrow_mut().push(x);
             }
             Word::Add => {
                 self.check(w, 2)?;
-                let x = self.pop(w, 2, 0)?;
-                let y = self.pop(w, 2, 1)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error @ add 1");
+                let y = self.stack.borrow_mut().pop().expect("Internal error @ add 2");
                 self.stack.borrow_mut().push(x.wrapping_add(y));
             }
             Word::Sub => {
                 self.check(w, 2)?;
-                let x = self.pop(w, 2, 0)?;
-                let y = self.pop(w, 2, 1)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error @ sub 1");
+                let y = self.stack.borrow_mut().pop().expect("Internal error @ sub 2");
                 self.stack.borrow_mut().push(x.wrapping_sub(y));
             }
             Word::Mul => {
                 self.check(w, 2)?;
-                let x = self.pop(w, 2, 0)?;
-                let y = self.pop(w, 2, 1)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error @ mul 1");
+                let y = self.stack.borrow_mut().pop().expect("Internal error @ mul 2");
                 self.stack.borrow_mut().push(x.wrapping_mul(y));
             }
             Word::Div => {
                 self.check(w, 2)?;
-                let x = self.pop(w, 2, 0)?;
-                let y = self.pop(w, 2, 1)?;
+                let x = self.stack.borrow_mut().pop().expect("Internall error @ div 1");
+                let y = self.stack.borrow_mut().pop().expect("Internall error @ div 2");
                 if y == 0 {
                     return Err(Error::NNZ(w.to_string()));
                 }
@@ -129,8 +123,8 @@ impl Machine {
             }
             Word::Mod => {
                 self.check(w, 2)?;
-                let x = self.pop(w, 2, 0)?;
-                let y = self.pop(w, 2, 1)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error @ mod 1");
+                let y = self.stack.borrow_mut().pop().expect("Internal error @ mod 2");
                 if y == 0 {
                     return Err(Error::NNZ(w.to_string()));
                 }
@@ -138,9 +132,9 @@ impl Machine {
             }
             Word::Zero => {
                 self.check(w, 3)?;
-                let x = self.pop(w, 3, 0)?;
-                let y = self.pop(w, 3, 1)?;
-                let z = self.pop(w, 3, 2)?;
+                let x = self.stack.borrow_mut().pop().expect("Internal error at zero? 1");
+                let y = self.stack.borrow_mut().pop().expect("Internal error at zero? 2");
+                let z = self.stack.borrow_mut().pop().expect("Internal error at zero? 3");
                 self.stack.borrow_mut().push(if x == 0 { y } else { z });
             }
             Word::Num(n) => self.stack.borrow_mut().push(*n),

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -117,6 +117,8 @@ impl Machine {
                 let x = self.stack.borrow_mut().pop().expect("Internall error @ div 1");
                 let y = self.stack.borrow_mut().pop().expect("Internall error @ div 2");
                 if y == 0 {
+                    self.stack.borrow_mut().push(y);
+                    self.stack.borrow_mut().push(x);
                     return Err(Error::NNZ(w.to_string()));
                 }
                 self.stack.borrow_mut().push(x.wrapping_div(y));
@@ -126,6 +128,8 @@ impl Machine {
                 let x = self.stack.borrow_mut().pop().expect("Internal error @ mod 1");
                 let y = self.stack.borrow_mut().pop().expect("Internal error @ mod 2");
                 if y == 0 {
+                    self.stack.borrow_mut().push(y);
+                    self.stack.borrow_mut().push(x);
                     return Err(Error::NNZ(w.to_string()));
                 }
                 self.stack.borrow_mut().push(x.wrapping_rem(y));

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -69,10 +69,10 @@ impl Machine {
     }
     fn eval(&mut self, w: &Word) -> Result<(), Error> {
         let r = match w {
+            Word::Num(_) | Word::Custom(_) => 0,
             Word::Pop | Word::Dup => 1,
             Word::Swap | Word::Add | Word::Sub | Word::Mul | Word::Div | Word::Mod => 2,
             Word::Zero => 3,
-            _ => 0,
         };
         let s = self.stack.len();
         if s < r {
@@ -285,7 +285,8 @@ mod tests {
             transition: <Self::Reference as ReferenceStateMachine>::Transition,
         ) -> Self::SystemUnderTest {
             let w = Word::from(transition);
-            sut.eval(&w).unwrap_or_else(|e| panic!("{w} raised an error: {e}"));
+            sut.eval(&w)
+                .unwrap_or_else(|e| panic!("{w} raised an error: {e}"));
             for (x, y) in sut.stack.iter().zip(r#ref.iter()) {
                 assert_eq!(x, y, "Different values in stacks: sut={x}, ref={y}");
             }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -84,6 +84,7 @@ impl Machine {
 }
 
 /// Broken out to untangle mutability concerns.
+/// Full of `stack.pop().expect(…)` because this should only be called from within `Machine::eval`.
 fn eval_inner(
     env: &IndexMap<String, Vec<Word>>,
     stack: &mut Vec<i64>,

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -121,8 +121,8 @@ fn eval_inner(
             stack.push(x.wrapping_mul(y));
         }
         Word::Div => {
-            let x = stack.pop().expect("Internall error @ div 1");
-            let y = stack.pop().expect("Internall error @ div 2");
+            let x = stack.pop().expect("Internal error @ div 1");
+            let y = stack.pop().expect("Internal error @ div 2");
             if y == 0 {
                 stack.push(y);
                 stack.push(x);
@@ -285,7 +285,7 @@ mod tests {
             transition: <Self::Reference as ReferenceStateMachine>::Transition,
         ) -> Self::SystemUnderTest {
             let w = Word::from(transition);
-            sut.eval(&w).unwrap_or_else(|_| panic!("{w}"));
+            sut.eval(&w).unwrap_or_else(|e| panic!("{w} raised an error: {e}"));
             for (x, y) in sut.stack.iter().zip(r#ref.iter()) {
                 assert_eq!(x, y, "Different values in stacks: sut={x}, ref={y}");
             }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -146,7 +146,7 @@ mod tests {
 
     prop_state_machine! {
         #[test]
-        fn state_machine_testing(sequential 0..100 => Machine);
+        fn state_machine_testing(sequential 1..100 => Machine);
     }
 
     #[derive(Debug, Clone, Copy, proptest_derive::Arbitrary)]

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -7,7 +7,7 @@ use std::{cell::RefCell, convert::TryFrom, fmt};
 #[derive(Default)]
 pub struct Machine {
     env: RefCell<IndexMap<String, Vec<Word>>>,
-    stack: RefCell<Vec<Word>>,
+    stack: RefCell<Vec<i64>>,
 }
 
 impl fmt::Display for Machine {
@@ -67,7 +67,7 @@ impl Machine {
         }
         Ok(())
     }
-    fn pop(&self, w: &Word, required: usize, stack_len: usize) -> Result<Word, Error> {
+    fn pop(&self, w: &Word, required: usize, stack_len: usize) -> Result<i64, Error> {
         self.stack
             .borrow_mut()
             .pop()
@@ -88,43 +88,43 @@ impl Machine {
                 self.stack.borrow_mut().push(x);
             }
             Word::Add => {
-                let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
-                let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x.wrapping_add(y)));
+                let x = self.pop(w, 2, 0)?;
+                let y = self.pop(w, 2, 1)?;
+                self.stack.borrow_mut().push(x.wrapping_add(y));
             }
             Word::Sub => {
-                let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
-                let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x.wrapping_sub(y)));
+                let x = self.pop(w, 2, 0)?;
+                let y = self.pop(w, 2, 1)?;
+                self.stack.borrow_mut().push(x.wrapping_sub(y));
             }
             Word::Mul => {
-                let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
-                let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
-                self.stack.borrow_mut().push(Word::Num(x.wrapping_mul(y)));
+                let x = self.pop(w, 2, 0)?;
+                let y = self.pop(w, 2, 1)?;
+                self.stack.borrow_mut().push(x.wrapping_mul(y));
             }
             Word::Div => {
-                let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
-                let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
+                let x = self.pop(w, 2, 0)?;
+                let y = self.pop(w, 2, 1)?;
                 if y == 0 {
                     return Err(Error::NNZ(w.to_string()));
                 }
-                self.stack.borrow_mut().push(Word::Num(x.wrapping_div(y)));
+                self.stack.borrow_mut().push(x.wrapping_div(y));
             }
             Word::Mod => {
-                let x = self.pop(w, 2, 0).and_then(i64::try_from)?;
-                let y = self.pop(w, 2, 1).and_then(i64::try_from)?;
+                let x = self.pop(w, 2, 0)?;
+                let y = self.pop(w, 2, 1)?;
                 if y == 0 {
                     return Err(Error::NNZ(w.to_string()));
                 }
-                self.stack.borrow_mut().push(Word::Num(x.wrapping_rem(y)));
+                self.stack.borrow_mut().push(x.wrapping_rem(y));
             }
             Word::Zero => {
-                let x = self.pop(w, 3, 0).and_then(i64::try_from)?;
+                let x = self.pop(w, 3, 0)?;
                 let y = self.pop(w, 3, 1)?;
                 let z = self.pop(w, 3, 2)?;
                 self.stack.borrow_mut().push(if x == 0 { y } else { z });
             }
-            Word::Num(_) => self.stack.borrow_mut().push(w.clone()),
+            Word::Num(n) => self.stack.borrow_mut().push(*n),
             Word::Custom(w) => match self.env.borrow().get(w) {
                 None => return Err(Error::Unknown(w.to_string())),
                 Some(vs) => {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,13 +1,23 @@
+#![allow(unsafe_code)]
 use crate::{error::Error, token::Token, word::Word};
 use indexmap::IndexMap;
 use logos::Logos;
 use std::{convert::TryFrom, fmt};
 
 /// The main data structure: a stack machine with an environment of local definitions.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct Machine {
     env: IndexMap<String, Vec<Word>>,
     stack: Vec<i64>,
+}
+
+impl Default for Machine {
+    fn default() -> Self {
+        Self {
+            env: IndexMap::with_capacity(1_024),
+            stack: Vec::with_capacity(1024),
+        }
+    }
 }
 
 impl fmt::Display for Machine {
@@ -67,24 +77,24 @@ impl Machine {
         }
         Ok(())
     }
-    fn eval(&mut self, w: &Word) -> Result<(), Error> {
-        self.check(w)?;
-        eval_inner(&self.env, &mut self.stack, w)
+    fn eval(&mut self, word: &Word) -> Result<(), Error> {
+        self.check(word)?;
+        eval_inner(&self.env, &mut self.stack, word)
     }
-    fn check(&self, w: &Word) -> Result<(), Error> {
+    fn check(&self, word: &Word) -> Result<(), Error> {
         let s = self.stack.len();
-        let r = match w {
+        let r = match word {
             Word::Num(_) | Word::Custom(_) => 0,
             Word::Pop | Word::Dup => 1,
             Word::Swap | Word::Add | Word::Sub | Word::Mul | Word::Div | Word::Mod => 2,
             Word::Zero => 3,
         };
         if s < r {
-            Err(Error::Small(w.to_string(), r, s))
-        } else if (*w == Word::Div || *w == Word::Mod) && self.stack[s - 2] == 0 {
-            Err(Error::NNZ(w.to_string()))
-        } else if matches!(w, Word::Custom(_)) && !self.env.contains_key(&w.to_string()) {
-            Err(Error::Unknown(w.to_string()))
+            Err(Error::Small(word.to_string(), r, s))
+        } else if (*word == Word::Div || *word == Word::Mod) && self.stack[s - 2] == 0 {
+            Err(Error::NNZ(word.to_string()))
+        } else if matches!(word, Word::Custom(_)) && !self.env.contains_key(&word.to_string()) {
+            Err(Error::Unknown(word.to_string()))
         } else {
             Ok(())
         }
@@ -92,61 +102,58 @@ impl Machine {
 }
 
 /// Broken out to untangle mutability concerns.
-/// Full of `stack.pop().expect(…)` because this should only be called from within `Machine::eval`.
+/// Full of **UNSAFE** code because this should only be called from within `Machine::eval`.
 fn eval_inner(
     env: &IndexMap<String, Vec<Word>>,
     stack: &mut Vec<i64>,
-    w: &Word,
+    word: &Word,
 ) -> Result<(), Error> {
-    match w {
-        Word::Pop => {
-            stack.pop().expect("Internal error @ pop");
+    let n = stack.len();
+    match word {
+        Word::Pop => unsafe { stack.set_len(n - 1) },
+        Word::Swap => stack.swap(n - 1, n - 2),
+        Word::Dup => stack.push(unsafe { *stack.get_unchecked(n - 1) }),
+        Word::Add => unsafe {
+            *stack.get_unchecked_mut(n - 2) = stack
+                .get_unchecked(n - 1)
+                .wrapping_add(*stack.get_unchecked(n - 2));
+            stack.set_len(n - 1);
+        },
+        Word::Sub => unsafe {
+            *stack.get_unchecked_mut(n - 2) = stack
+                .get_unchecked(n - 1)
+                .wrapping_sub(*stack.get_unchecked(n - 2));
+            stack.set_len(n - 1);
+        },
+        Word::Mul => unsafe {
+            *stack.get_unchecked_mut(n - 2) = stack
+                .get_unchecked(n - 1)
+                .wrapping_mul(*stack.get_unchecked(n - 2));
+            stack.set_len(n - 1);
+        },
+        Word::Div => unsafe {
+            *stack.get_unchecked_mut(n - 2) = stack
+                .get_unchecked(n - 1)
+                .wrapping_div(*stack.get_unchecked(n - 2));
+            stack.set_len(n - 1);
+        },
+        Word::Mod => unsafe {
+            *stack.get_unchecked_mut(n - 2) = stack
+                .get_unchecked(n - 1)
+                .wrapping_rem(*stack.get_unchecked(n - 2));
+            stack.set_len(n - 1);
+        },
+        Word::Zero => unsafe {
+            if *stack.get_unchecked(n - 1) == 0 {
+                stack.swap(n - 2, n - 3);
+            }
+            stack.set_len(n - 2);
+        },
+        Word::Num(x) => {
+            stack.push(*x);
         }
-        Word::Swap => {
-            let x = stack.pop().expect("Internal error @ swap 1");
-            let y = stack.pop().expect("Internal error @ swap 2");
-            stack.push(x);
-            stack.push(y);
-        }
-        Word::Dup => {
-            let x = stack.pop().expect("Internal error @ dup");
-            stack.push(x);
-            stack.push(x);
-        }
-        Word::Add => {
-            let x = stack.pop().expect("Internal error @ add 1");
-            let y = stack.pop().expect("Internal error @ add 2");
-            stack.push(x.wrapping_add(y));
-        }
-        Word::Sub => {
-            let x = stack.pop().expect("Internal error @ sub 1");
-            let y = stack.pop().expect("Internal error @ sub 2");
-            stack.push(x.wrapping_sub(y));
-        }
-        Word::Mul => {
-            let x = stack.pop().expect("Internal error @ mul 1");
-            let y = stack.pop().expect("Internal error @ mul 2");
-            stack.push(x.wrapping_mul(y));
-        }
-        Word::Div => {
-            let x = stack.pop().expect("Internal error @ div 1");
-            let y = stack.pop().expect("Internal error @ div 2");
-            stack.push(x.wrapping_div(y));
-        }
-        Word::Mod => {
-            let x = stack.pop().expect("Internal error @ mod 1");
-            let y = stack.pop().expect("Internal error @ mod 2");
-            stack.push(x.wrapping_rem(y));
-        }
-        Word::Zero => {
-            let x = stack.pop().expect("Internal error at zero? 1");
-            let y = stack.pop().expect("Internal error at zero? 2");
-            let z = stack.pop().expect("Internal error at zero? 3");
-            stack.push(if x == 0 { y } else { z });
-        }
-        Word::Num(n) => stack.push(*n),
-        Word::Custom(w) => {
-            for v in env.get(w).ok_or_else(|| Error::Unknown(w.to_string()))? {
+        Word::Custom(c) => {
+            for v in &env[c] {
                 eval_inner(env, stack, v)?;
             }
         }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -146,10 +146,10 @@ mod tests {
 
     prop_state_machine! {
         #[test]
-        fn state_machine_testing(sequential 1..20 => Machine);
+        fn state_machine_testing(sequential 0..100 => Machine);
     }
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug, Clone, Copy, proptest_derive::Arbitrary)]
     pub enum Op {
         Push(i64),
         Pop,
@@ -189,7 +189,6 @@ mod tests {
             Just(Vec::new()).boxed()
         }
         fn preconditions(state: &Self::State, transition: &Self::Transition) -> bool {
-            dbg!((&state, &transition));
             match transition {
                 Op::Push(_) => true,
                 Op::Pop | Op::Dup => !state.is_empty(),
@@ -201,19 +200,7 @@ mod tests {
             }
         }
         fn transitions(_: &Self::State) -> BoxedStrategy<Self::Transition> {
-            prop_oneof![
-                any::<i64>().prop_map(Op::Push),
-                Just(Op::Pop),
-                Just(Op::Swap),
-                Just(Op::Dup),
-                Just(Op::Add),
-                Just(Op::Sub),
-                Just(Op::Mul),
-                Just(Op::Div),
-                Just(Op::Mod),
-                Just(Op::Zero),
-            ]
-            .boxed()
+            any::<Self::Transition>().boxed()
         }
         fn apply(mut state: Self::State, transition: &Self::Transition) -> Self::State {
             match transition {

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -212,9 +212,7 @@ mod tests {
                 Op::Push(_) => true,
                 Op::Pop | Op::Dup => !state.is_empty(),
                 Op::Swap | Op::Add | Op::Sub | Op::Mul => state.len() > 1,
-                Op::Div | Op::Mod => {
-                    state.len() > 1 && state[state.len() - 1] > 0 && state[state.len() - 2] > 0
-                }
+                Op::Div | Op::Mod => state.len() > 1 && state[state.len() - 2] > 0,
                 Op::Zero => state.len() > 2,
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,7 @@ fn main() -> Result<(), Error> {
             if r.load_history("history.txt").is_err() {
                 eprintln!("No previous history.");
             }
-            let m = Machine::default();
+            let mut m = Machine::default();
             loop {
                 match r.readline(">  ") {
                     Ok(l) => {
@@ -107,7 +107,7 @@ fn main() -> Result<(), Error> {
         }
         Command::Run { file } => {
             let f = File::open(file)?;
-            let m = Machine::default();
+            let mut m = Machine::default();
             for line in BufReader::new(f).lines() {
                 m.read_eval(&line?)?;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,9 +107,8 @@ fn main() -> Result<(), Error> {
             r.save_history("history.txt")?;
         }
         Command::Run { file } => {
-            let f = File::open(file)?;
             let mut m = Machine::default();
-            for line in BufReader::new(f).lines() {
+            for line in BufReader::new(File::open(file)?).lines() {
                 m.read_eval(&line?)?;
             }
             println!("{m}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,8 @@ enum Command {
     Run { file: PathBuf },
 }
 
-#[derive(Debug, Clone, Copy, ValueEnum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 enum Mode {
     Vi,
     Emacs,
@@ -115,4 +116,16 @@ fn main() -> Result<(), Error> {
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    proptest! {
+        #[test]
+        fn mode_roundtrip(m: Mode) {
+            prop_assert_eq!(m, ValueEnum::from_str(&m.to_string(), false).unwrap());
+        }
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,6 @@ enum Command {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
-#[cfg_attr(test, derive(proptest_derive::Arbitrary))]
 enum Mode {
     Vi,
     Emacs,
@@ -121,10 +120,15 @@ fn main() -> Result<(), Error> {
 mod tests {
     use super::*;
     use proptest::prelude::*;
+
     proptest! {
         #[test]
-        fn mode_roundtrip(m: Mode) {
+        fn mode_roundtrip(m in mode()) {
             prop_assert_eq!(m, ValueEnum::from_str(&m.to_string(), false).unwrap());
         }
+    }
+
+    fn mode() -> impl Strategy<Value = Mode> {
+        prop_oneof![Just(Mode::Vi), Just(Mode::Emacs)]
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -35,12 +35,11 @@ impl fmt::Display for Token<'_> {
     }
 }
 
-
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use proptest::prelude::*;
     use logos::Logos;
+    use proptest::prelude::*;
 
     proptest! {
         #[test]

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,5 @@
 use logos::Logos;
+use std::fmt;
 
 /// Tokens are lexed from input strings.
 #[derive(Logos, Debug, PartialEq, Eq, Clone)]
@@ -9,7 +10,7 @@ pub enum Token<'source> {
     #[token("def")]
     Def,
     /// A core word.
-    #[regex(r"(pop|swap|dup|add|sub|mul|div|mod|zero)")]
+    #[regex(r"(pop|swap|dup|add|sub|mul|div|mod|zero[?])")]
     Core(&'source str),
     /// An integer in decimal notation.
     #[regex(r"-?[0-9]+", |lex| lex.slice().parse())]
@@ -20,4 +21,57 @@ pub enum Token<'source> {
     /// A (possibly unknown) custom token.
     #[regex(r"\S+", priority = 0)]
     Custom(&'source str),
+}
+
+impl fmt::Display for Token<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::Def => f.write_str("def"),
+            Self::Core(s) => f.write_str(s),
+            Self::Num(n) => write!(f, "{n}"),
+            Self::Hex(n) => write!(f, "#{n:x}"),
+            Self::Custom(w) => write!(f, "{w}"),
+        }
+    }
+}
+
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use logos::Logos;
+
+    proptest! {
+        #[test]
+        fn roundtrip(t in token()) {
+            let s = t.to_string();
+            let ts = Token::lexer(&s).collect::<Result<Vec<_>, _>>();
+            prop_assert!(ts.is_ok());
+            let mut ts = ts.unwrap();
+            prop_assert_eq!(ts.len(), 1);
+            let t2 = ts.pop().unwrap();
+            prop_assert_eq!(t2, t);
+        }
+    }
+
+    // NOTE: I can't get Token::Custom to generate due to lifetime issues, and I don't want to just
+    // use proptest_derive::Arbitrary since it'll put a _lot_ of junk into Token::Core &
+    // Token::Custom.
+    pub fn token() -> impl Strategy<Value = Token<'static>> {
+        prop_oneof![
+            Just(Token::Def),
+            Just(Token::Core("pop")),
+            Just(Token::Core("swap")),
+            Just(Token::Core("dup")),
+            Just(Token::Core("add")),
+            Just(Token::Core("sub")),
+            Just(Token::Core("mul")),
+            Just(Token::Core("div")),
+            Just(Token::Core("mod")),
+            Just(Token::Core("zero?")),
+            any::<i64>().prop_map(Token::Num),
+            (0..i64::MAX).prop_map(Token::Hex),
+        ]
+    }
 }

--- a/src/word.rs
+++ b/src/word.rs
@@ -66,7 +66,7 @@ impl TryFrom<Token<'_>> for Word {
                 _ => Err(Error::Unknown(w.to_string())),
             },
             Token::Num(n) | Token::Hex(n) => Ok(Self::Num(n)),
-            Token::Custom(w) => Ok(Self::Custom(w.into())),
+            Token::Custom(w) => Ok(Self::Custom(w.to_string())),
         }
     }
 }
@@ -97,5 +97,66 @@ impl Word {
             Self::Num(n) => Err(Error::NumNotName(n)),
             _ => Err(Error::CoreNotName(self.to_string())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::token::tests::token, *};
+    use logos::Logos;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn from_token(t in token()) {
+            let w = Word::try_from(t.clone());
+            prop_assert_eq!(w.is_ok(), t != Token::Def);
+        }
+        #[test]
+        fn self_eq(w in word()) {
+            prop_assert_eq!(w.clone(), w);
+        }
+        #[test]
+        #[allow(clippy::cmp_owned)]
+        fn str_eq(w in word(), s in r"\S+") {
+            prop_assert_eq!(w == s, w.to_string() == s);
+        }
+        #[test]
+        fn roundtrip(w in word()) {
+            let s = w.to_string();
+            let ts = Token::lexer(&s).collect::<Result<Vec<Token>, _>>();
+            prop_assert!(ts.is_ok());
+            let mut ts = ts.unwrap();
+            prop_assert_eq!(ts.len(), 1);
+            let w2 = Word::try_from(ts.pop().unwrap());
+            prop_assert!(w2.is_ok());
+            prop_assert_eq!(w, w2.unwrap());
+        }
+        #[test]
+        fn into_num(w in word()) {
+            let n = i64::try_from(w.clone());
+            prop_assert_eq!(n.is_ok(), w == Word::Num(n.unwrap_or_default()));
+        }
+        #[test]
+        fn into_name(w in word()) {
+            let n = w.clone().into_name();
+            prop_assert_eq!(n.is_ok(), w == Word::Custom(n.unwrap_or_default()));
+        }
+    }
+
+    pub fn word() -> impl Strategy<Value = Word> {
+        prop_oneof![
+            Just(Word::Pop),
+            Just(Word::Swap),
+            Just(Word::Dup),
+            Just(Word::Add),
+            Just(Word::Sub),
+            Just(Word::Mul),
+            Just(Word::Div),
+            Just(Word::Mod),
+            Just(Word::Zero),
+            any::<i64>().prop_map(Word::Num),
+            r"[a-zA-Z]+".prop_map(Word::Custom)
+        ]
     }
 }

--- a/src/word.rs
+++ b/src/word.rs
@@ -71,16 +71,6 @@ impl TryFrom<Token<'_>> for Word {
     }
 }
 
-impl TryFrom<Word> for i64 {
-    type Error = Error;
-    fn try_from(w: Word) -> Result<Self, Self::Error> {
-        match w {
-            Word::Num(n) => Ok(n),
-            _ => Err(Error::NaN(w.to_string())),
-        }
-    }
-}
-
 impl PartialEq<String> for Word {
     fn eq(&self, s: &String) -> bool {
         match self {
@@ -131,11 +121,6 @@ mod tests {
             let w2 = Word::try_from(ts.pop().unwrap());
             prop_assert!(w2.is_ok());
             prop_assert_eq!(w, w2.unwrap());
-        }
-        #[test]
-        fn into_num(w in word()) {
-            let n = i64::try_from(w.clone());
-            prop_assert_eq!(n.is_ok(), w == Word::Num(n.unwrap_or_default()));
         }
         #[test]
         fn into_name(w in word()) {

--- a/src/word.rs
+++ b/src/word.rs
@@ -91,7 +91,7 @@ impl Word {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::{super::token::tests::token, *};
     use logos::Logos;
     use proptest::prelude::*;


### PR DESCRIPTION
_All hail [`proptest`](https://github.com/proptest-rs/proptest)!_

I (of course) encountered some crashes (cuz I wasn't careful before). Now, all arithmetic is wrapping, and there's a new error for division or modulo by zero.

Coverage is much better (than nothing) according to [`cargo tarpaulin`](https://github.com/xd009642/tarpaulin):

```
2025-05-12T19:12:07.626294Z  INFO cargo_tarpaulin::report: Coverage Results:
|| Uncovered Lines:
|| src/machine.rs: 14-25, 27, 29-31, 33-35, 37, 46-49, 51, 53-60, 62-63, 65, 68, 109, 117, 128-132
|| src/main.rs: 42-45, 51-54, 69-82, 84-85, 87, 89-94, 98-99, 101-102, 104, 106, 108-112, 114, 117
|| src/token.rs: 33
|| src/word.rs: 66
|| Tested/Total Lines:
|| src/machine.rs: 27/71
|| src/main.rs: 0/44
|| src/token.rs: 6/7
|| src/word.rs: 41/42
||
45.12% coverage, 74/164 lines covered
```

This is also the first time I've used `propest_state_machine`, which is nice.

2 **NOTE**s remain in the testing code:

1. I can't get `Token::Custom` to generate due to lifetime issues, and I don't want to just use `proptest_derive::Arbitrary` since it'll put a _lot_ of junk into `Token::Core` & `Token::Custom.`
2. I don't have any `Custom(w)` ops in the state machine testing.