### PR TITLE
Some housekeeping things

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "drsm"
 description = "Dylan's Rusty Stack Machine"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 
 [dependencies]
-clap = { version = "4.5.37", features = ["derive"] }
+clap = { version = "4.5.38", features = ["derive"] }
 indexmap = "2.9.0"
 logos = "0.15.0"
 rustyline = "15.0.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,7 +37,7 @@ pub enum Error {
     /// `def` needs a body, but none was supplied.
     #[error("`def` needs a body, but none was supplied.")]
     DefBody,
-    /// `{0}` requires its second operand be nonzero
-    #[error("`{0}` requires its second operand be nonzero")]
+    /// `{0}` requires its second operand be nonzero.
+    #[error("`{0}` requires its second operand be nonzero.")]
     NNZ(String),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ enum Command {
     #[command(about = "run an interactive REPL")]
     Repl {
         #[arg(short, long, default_value_t = Mode::Vi)]
-        edit_mode: Mode,
+        mode: Mode,
     },
     #[command(about = "execute the commands in a file")]
     Run { file: PathBuf },
@@ -69,9 +69,9 @@ enum Error {
 fn main() -> Result<(), Error> {
     let args = Args::parse();
     match args.command {
-        Command::Repl { edit_mode } => {
+        Command::Repl { mode } => {
             let mut r =
-                DefaultEditor::with_config(Config::builder().edit_mode(edit_mode.into()).build())?;
+                DefaultEditor::with_config(Config::builder().edit_mode(mode.into()).build())?;
             println!(
                 r"
     ____  ____  _____ __  ___

--- a/src/token.rs
+++ b/src/token.rs
@@ -52,11 +52,21 @@ pub mod tests {
             let t2 = ts.pop().unwrap();
             prop_assert_eq!(t2, t);
         }
+        #[test]
+        fn custom_roundtrip(s in r"\S+") {
+            let t = Token::Custom(&s);
+            prop_assert_eq!(&t.to_string(), &s);
+            let ts = Token::lexer(&s).collect::<Result<Vec<_>, _>>();
+            prop_assert!(ts.is_ok());
+            let mut ts = ts.unwrap();
+            prop_assert_eq!(ts.len(), 1);
+            let t2 = ts.pop().unwrap();
+            prop_assert_eq!(t2, t);
+        }
     }
 
-    // NOTE: I can't get Token::Custom to generate due to lifetime issues, and I don't want to just
-    // use proptest_derive::Arbitrary since it'll put a _lot_ of junk into Token::Core &
-    // Token::Custom.
+    // NOTE: I can't get Token::Custom to generate due to lifetime issues, and
+    // proptest_derive::Arbitrary doesn't allow generic lifetimes.
     pub fn token() -> impl Strategy<Value = Token<'static>> {
         prop_oneof![
             Just(Token::Def),

--- a/src/word.rs
+++ b/src/word.rs
@@ -62,8 +62,7 @@ impl TryFrom<Token<'_>> for Word {
                 s if s == Self::Div.to_string() => Ok(Self::Div),
                 s if s == Self::Mod.to_string() => Ok(Self::Mod),
                 s if s == Self::Zero.to_string() => Ok(Self::Zero),
-                // Should be unreachable, but let's be careful.
-                _ => Err(Error::Unknown(w.to_string())),
+                _ => unreachable!("Core tokens match core words"),
             },
             Token::Num(n) | Token::Hex(n) => Ok(Self::Num(n)),
             Token::Custom(w) => Ok(Self::Custom(w.to_string())),
@@ -73,10 +72,7 @@ impl TryFrom<Token<'_>> for Word {
 
 impl PartialEq<String> for Word {
     fn eq(&self, s: &String) -> bool {
-        match self {
-            Self::Custom(w) => w == s,
-            _ => false,
-        }
+        matches!(self, Self::Custom(w) if w == s)
     }
 }
 


### PR DESCRIPTION
- bumped `clap` patch version
- added a period to the end of an error message
- updated `NOTE` about `Token::Custom` `proptest` generation
- tightened up code in `impl PartialEq<String> for Word`
- reached full test coverage of library code!

```
2025-05-15T20:59:52.778498Z  INFO cargo_tarpaulin::report: Coverage Results:
|| Uncovered Lines:
|| src/main.rs: 51-54, 69-82, 84-85, 87, 89-94, 98-99, 101-102, 104, 106, 108-111, 113, 116
|| Tested/Total Lines:
|| src/machine.rs: 98/98
|| src/main.rs: 4/43
|| src/token.rs: 7/7
|| src/word.rs: 35/35
||
78.69% coverage, 144/183 lines covered
```