### PR TITLE
various noodlings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "drsm"
 description = "Dylan's Rusty Stack Machine"
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 
 [dependencies]
-clap = { version = "4.5.38", features = ["derive"] }
+clap = { version = "4.5.39", features = ["derive"] }
 indexmap = "2.9.0"
 logos = "0.15.0"
-rustyline = "15.0.0"
+rustyline = "16.0.0"
 thiserror = "2.0.12"
 
 [profile.dev]

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,4 +40,7 @@ pub enum Error {
     /// `{0}` requires its second operand be nonzero.
     #[error("`{0}` requires its second operand be nonzero.")]
     NNZ(String),
+    /// `mod` would error with arguments (`i64::MIN`, -1)
+    #[error("`mod` would error with arguments (`i64::MIN`, -1)")]
+    ModEdge,
 }


### PR DESCRIPTION
Biggest thing: REPL quality-of-life improvements!

- commands `?`, `?show`, `?lookup <w>`, and `?quit`
- wordier banner
- only print if asked to via the `print` word, & don't print the whole machine

Other stuff:

- version bump
- deps bump
- smaller capacity for default machine parts
- renamed `pop` to `drop` to feel more Forth-y
- added `print` core word
- switched to saturating arithmetic, covered a `mod` edge case