### PR TITLE
factor out into Core type; add documentation for it at REPL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "drsm"
 description = "Dylan's Rusty Stack Machine"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 
 [dependencies]
 clap = { version = "4.5.40", features = ["derive"] }
+documented = "0.9.1"
 indexmap = "2.9.0"
 logos = "0.15.0"
 rustyline = "16.0.0"
+strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.12"
 
 [profile.dev]

--- a/src/core.rs
+++ b/src/core.rs
@@ -6,7 +6,7 @@
     Copy,
     Debug,
     documented::Documented,
-    documented::DocumentedVariants,
+    documented::DocumentedFields,
     strum::Display,
     strum::EnumIter,
     strum::EnumString,
@@ -47,7 +47,7 @@ pub mod tests {
             let s = c.to_string();
             let c2 = s.parse::<Core>();
             prop_assert!(c2.is_ok());
-            prop_assert_eq!(c2.unwrap(), c)
+            prop_assert_eq!(c2.unwrap(), c);
         }
     }
 

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,0 +1,68 @@
+/// Core words/tokens
+#[derive(
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    Debug,
+    documented::Documented,
+    documented::DocumentedVariants,
+    strum::Display,
+    strum::EnumIter,
+    strum::EnumString,
+)]
+#[strum(serialize_all = "lowercase")]
+pub enum Core {
+    /// Pop an item off the stack, ignoring it.
+    Drop,
+    /// Swap the top two elements of the stack.
+    Swap,
+    /// Duplicate the first element of the stack.
+    Dup,
+    /// Add the first two elements of the stack.
+    Add,
+    /// Subtract the second from the first element of the stack.
+    Sub,
+    /// Multiply the first two elements of the stack.
+    Mul,
+    /// Divide the second into the first element of the stack.
+    Div,
+    /// Take the remainder of the second in the first element of the stack.
+    Mod,
+    /// Pop 3 elements. If the first is zero, push the second back on; otherwise, push the third.
+    #[strum(serialize = "zero?")]
+    Zero,
+    /// Pop an element off the stack and print it.
+    Print,
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn roundtrip(c in core()) {
+            let s = c.to_string();
+            let c2 = s.parse::<Core>();
+            prop_assert!(c2.is_ok());
+            prop_assert_eq!(c2.unwrap(), c)
+        }
+    }
+
+    pub fn core() -> impl Strategy<Value = Core> {
+        prop_oneof![
+            Just(Core::Drop),
+            Just(Core::Swap),
+            Just(Core::Dup),
+            Just(Core::Add),
+            Just(Core::Sub),
+            Just(Core::Mul),
+            Just(Core::Div),
+            Just(Core::Mod),
+            Just(Core::Zero),
+            Just(Core::Print),
+        ]
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,9 +5,10 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 
+mod core;
 mod error;
 mod machine;
 mod token;
 mod word;
 
-pub use crate::{error::Error, machine::Machine};
+pub use crate::{core::Core, error::Error, machine::Machine};

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -97,7 +97,7 @@ fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Resul
         Err(Error::Small(word.to_string(), r, s))
     } else if matches!(word, Word::Core(Core::Div | Core::Mod)) && stack[s - 2] == 0 {
         Err(Error::NNZ(word.to_string()))
-    } else if *word == Word::Core(Core::Mod) && matches!(stack[s-2..s], [i64::MIN, -1]) {//stack[s - 1] == i64::MIN && stack[s - 2] == -1 {
+    } else if *word == Word::Core(Core::Mod) && matches!(stack[s-2..s], [-1, i64::MIN]) {
         Err(Error::ModEdge)
     } else if matches!(word, Word::Custom(_)) && !env.contains_key(&word.to_string()) {
         Err(Error::Unknown(word.to_string()))

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -97,7 +97,7 @@ fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Resul
         Err(Error::Small(word.to_string(), r, s))
     } else if matches!(word, Word::Core(Core::Div | Core::Mod)) && stack[s - 2] == 0 {
         Err(Error::NNZ(word.to_string()))
-    } else if *word == Word::Core(Core::Mod) && matches!(stack[s-2..s], [-1, i64::MIN]) {
+    } else if *word == Word::Core(Core::Mod) && matches!(stack[s - 2..s], [-1, i64::MIN]) {
         Err(Error::ModEdge)
     } else if matches!(word, Word::Custom(_)) && !env.contains_key(&word.to_string()) {
         Err(Error::Unknown(word.to_string()))

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -95,11 +95,9 @@ fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Resul
     };
     if s < r {
         Err(Error::Small(word.to_string(), r, s))
-    } else if (*word == Word::Core(Core::Div) || *word == Word::Core(Core::Mod))
-        && stack[s - 2] == 0
-    {
+    } else if matches!(word, Word::Core(Core::Div | Core::Mod)) && stack[s - 2] == 0 {
         Err(Error::NNZ(word.to_string()))
-    } else if *word == Word::Core(Core::Mod) && stack[s - 1] == i64::MIN && stack[s - 2] == -1 {
+    } else if *word == Word::Core(Core::Mod) && matches!(stack[s-2..s], [i64::MIN, -1]) {//stack[s - 1] == i64::MIN && stack[s - 2] == -1 {
         Err(Error::ModEdge)
     } else if matches!(word, Word::Custom(_)) && !env.contains_key(&word.to_string()) {
         Err(Error::Unknown(word.to_string()))

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 use clap::{Parser, Subcommand, ValueEnum};
-use documented::DocumentedVariants;
+use documented::DocumentedFields;
 use drsm::{Core, Machine};
 use rustyline::{Config, DefaultEditor, EditMode, error::ReadlineError};
 use std::{
@@ -110,10 +110,8 @@ Line-editing is enabled, with {mode}-style key bindings (chosen at startup via t
                     }
                     Ok(l) if l.starts_with("?lookup ") => {
                         if let Some(w) = l.split_ascii_whitespace().nth(1) {
-                            match (w.parse::<Core>(), m.lookup(w)) {
-                                (Ok(c), _) => {
-                                    println!("`{w}` is a core word: {}", c.get_variant_docs())
-                                }
+                            match (Core::get_field_docs(w), m.lookup(w)) {
+                                (Ok(d), _) => println!("`{w}` is a core word: {d}"),
                                 (Err(_), Some(d)) => println!("{d}"),
                                 (Err(_), None) => {
                                     eprintln!("`{w}` is not defined in the environment.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ Line-editing is enabled, with {mode}-style key bindings (chosen at startup via t
                         if let Some(w) = l.split_ascii_whitespace().nth(1) {
                             match (Core::get_field_docs(w), m.lookup(w)) {
                                 (Ok(d), _) => println!("`{w}` is a core word: {d}"),
-                                (_, Some(d)) => println!("{d}"),
+                                (_, Some(d)) => println!("`{w}` is defind as {d}"),
                                 (_, None) => eprintln!("`{w}` is not defined in the environment."),
                             }
                         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,10 +112,8 @@ Line-editing is enabled, with {mode}-style key bindings (chosen at startup via t
                         if let Some(w) = l.split_ascii_whitespace().nth(1) {
                             match (Core::get_field_docs(w), m.lookup(w)) {
                                 (Ok(d), _) => println!("`{w}` is a core word: {d}"),
-                                (Err(_), Some(d)) => println!("{d}"),
-                                (Err(_), None) => {
-                                    eprintln!("`{w}` is not defined in the environment.");
-                                }
+                                (_, Some(d)) => println!("{d}"),
+                                (_, None) => eprintln!("`{w}` is not defined in the environment."),
                             }
                         } else {
                             eprintln!("?lookup requires a word to look up.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,8 @@
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
 use clap::{Parser, Subcommand, ValueEnum};
-use drsm::Machine;
+use documented::DocumentedVariants;
+use drsm::{Core, Machine};
 use rustyline::{Config, DefaultEditor, EditMode, error::ReadlineError};
 use std::{
     fmt,
@@ -109,9 +110,14 @@ Line-editing is enabled, with {mode}-style key bindings (chosen at startup via t
                     }
                     Ok(l) if l.starts_with("?lookup ") => {
                         if let Some(w) = l.split_ascii_whitespace().nth(1) {
-                            match m.lookup(w) {
-                                Some(d) => println!("{d}"),
-                                None => eprintln!("`{w}` is not defined in the environment."),
+                            match (w.parse::<Core>(), m.lookup(w)) {
+                                (Ok(c), _) => {
+                                    println!("`{w}` is a core word: {}", c.get_variant_docs())
+                                }
+                                (Err(_), Some(d)) => println!("{d}"),
+                                (Err(_), None) => {
+                                    eprintln!("`{w}` is not defined in the environment.");
+                                }
                             }
                         } else {
                             eprintln!("?lookup requires a word to look up.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,7 @@ Line-editing is enabled, with {mode}-style key bindings (chosen at startup via t
                         if let Some(w) = l.split_ascii_whitespace().nth(1) {
                             match (Core::get_field_docs(w), m.lookup(w)) {
                                 (Ok(d), _) => println!("`{w}` is a core word: {d}"),
-                                (_, Some(d)) => println!("`{w}` is defind as {d}"),
+                                (_, Some(d)) => println!("`{w}` is defind as `{d}`"),
                                 (_, None) => eprintln!("`{w}` is not defined in the environment."),
                             }
                         } else {

--- a/src/word.rs
+++ b/src/word.rs
@@ -1,52 +1,18 @@
-use crate::{Error, token::Token};
-use std::{convert::TryFrom, fmt};
+use crate::{Error, core::Core, token::Token};
+use std::convert::TryFrom;
 
 /// The words upon which our stack machine works.
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, strum::Display)]
 pub enum Word {
-    /// Pop an item off the stack, ignoring it.
-    Drop,
-    /// Swap the top two elements of the stack.
-    Swap,
-    /// Duplicate the first element of the stack.
-    Dup,
-    /// Add the first two elements of the stack.
-    Add,
-    /// Subtract the second from the first element of the stack.
-    Sub,
-    /// Multiply the first two elements of the stack.
-    Mul,
-    /// Divide the second into the first element of the stack.
-    Div,
-    /// Take the remainder of the second in the first element of the stack.
-    Mod,
-    /// Pop 3 elements. If the first is zero, push the second back on; otherwise, push the third.
-    Zero,
-    /// Pop an element off the stack and print it.
-    Print,
+    /// A core word,
+    #[strum(serialize = "{0}")]
+    Core(Core),
     /// An integer.
+    #[strum(serialize = "{0}")]
     Num(i64),
     /// A custom word.
+    #[strum(serialize = "{0}")]
     Custom(String),
-}
-
-impl fmt::Display for Word {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            Self::Drop => f.write_str("drop"),
-            Self::Swap => f.write_str("swap"),
-            Self::Dup => f.write_str("dup"),
-            Self::Add => f.write_str("add"),
-            Self::Sub => f.write_str("sub"),
-            Self::Mul => f.write_str("mul"),
-            Self::Div => f.write_str("div"),
-            Self::Mod => f.write_str("mod"),
-            Self::Zero => f.write_str("zero?"),
-            Self::Print => f.write_str("print"),
-            Self::Num(n) => write!(f, "{n}"),
-            Self::Custom(w) => write!(f, "{w}"),
-        }
-    }
 }
 
 impl TryFrom<Token<'_>> for Word {
@@ -54,20 +20,7 @@ impl TryFrom<Token<'_>> for Word {
     fn try_from(t: Token<'_>) -> Result<Self, Self::Error> {
         match t {
             Token::Def => Err(Error::Reserved),
-            Token::Core(w) => match w {
-                // A verbose pattern rather than strings to ensure this matches the Display impl.
-                s if s == Self::Drop.to_string() => Ok(Self::Drop),
-                s if s == Self::Swap.to_string() => Ok(Self::Swap),
-                s if s == Self::Dup.to_string() => Ok(Self::Dup),
-                s if s == Self::Add.to_string() => Ok(Self::Add),
-                s if s == Self::Sub.to_string() => Ok(Self::Sub),
-                s if s == Self::Mul.to_string() => Ok(Self::Mul),
-                s if s == Self::Div.to_string() => Ok(Self::Div),
-                s if s == Self::Mod.to_string() => Ok(Self::Mod),
-                s if s == Self::Zero.to_string() => Ok(Self::Zero),
-                s if s == Self::Print.to_string() => Ok(Self::Print),
-                _ => unreachable!("Core tokens match core words"),
-            },
+            Token::Core(c) => Ok(Self::Core(c)),
             Token::Num(n) | Token::Hex(n) => Ok(Self::Num(n)),
             Token::Custom(w) => Ok(Self::Custom(w.to_string())),
         }
@@ -85,14 +38,17 @@ impl Word {
         match self {
             Self::Custom(w) => Ok(w),
             Self::Num(n) => Err(Error::NumNotName(n)),
-            _ => Err(Error::CoreNotName(self.to_string())),
+            Self::Core(_) => Err(Error::CoreNotName(self.to_string())),
         }
     }
 }
 
 #[cfg(test)]
 pub mod tests {
-    use super::{super::token::tests::token, *};
+    use super::{
+        super::{core::tests::core, token::tests::token},
+        *,
+    };
     use logos::Logos;
     use proptest::prelude::*;
 
@@ -131,16 +87,7 @@ pub mod tests {
 
     pub fn word() -> impl Strategy<Value = Word> {
         prop_oneof![
-            Just(Word::Drop),
-            Just(Word::Swap),
-            Just(Word::Dup),
-            Just(Word::Add),
-            Just(Word::Sub),
-            Just(Word::Mul),
-            Just(Word::Div),
-            Just(Word::Mod),
-            Just(Word::Zero),
-            Just(Word::Print),
+            core().prop_map(Word::Core),
             any::<i64>().prop_map(Word::Num),
             r"[a-zA-Z]+".prop_map(Word::Custom)
         ]


### PR DESCRIPTION
Putting the core words/tokens into their own type that the others reference seemed to make sense to me. I also grabbed `strum` to make enums easier to implement (`Display`, `EnumIter`, and `EnumString`).

Another crate I brought in: `documented`. This lets us access the enum docstrings as code, so e.g. we can provide them in the REPL when someone does a `?lookup`. Here's the new functionality in the REPL:

<img width="962" alt="Screenshot 2025-06-17 at 10 27 09 AM" src="https://github.com/user-attachments/assets/4ab3d563-b613-43ba-88cb-49d779e6a99b" />
