### PR TITLE
Benchmarking lead to using a special string type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 clap = { version = "4.5.45", features = ["derive"] }
 documented = "0.9.2"
 indexmap = "2.11.0"
+lean_string = "0.5.1"
 logos = "0.15.1"
 rustyline = "17.0.1"
 strum = { version = "0.27.2", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,4 +22,10 @@ codegen-units = 1
 panic = "abort"
 
 [dev-dependencies]
+criterion = "0.7.0"
+itertools = "0.14.0"
 proptest = "1.7.0"
+
+[[bench]]
+name = "benchmark"
+harness = false

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -10,17 +10,17 @@ fn fib_machine(n: u32) -> Machine {
         .tuple_windows()
         .map(|(i, j, k)| {
             (
-                format!("fib_{k}"),
+                format!("fib_{k}").into(),
                 vec![
-                    Word::Custom(format!("fib_{j}")),
-                    Word::Custom(format!("fib_{i}")),
+                    Word::Custom(format!("fib_{j}").into()),
+                    Word::Custom(format!("fib_{i}").into()),
                     Word::Core(Core::Add),
                 ],
             )
         })
         .collect::<IndexMap<_, _>>();
-    env.insert("fib_0".to_string(), vec![Word::Num(1)]);
-    env.insert("fib_1".to_string(), vec![Word::Num(1)]);
+    env.insert("fib_0".into(), vec![Word::Num(1)]);
+    env.insert("fib_1".into(), vec![Word::Num(1)]);
     Machine::with_env(env)
 }
 

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,0 +1,38 @@
+#![allow(clippy::type_complexity)]
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use drsm::{Core, Machine, Word};
+use indexmap::IndexMap;
+use itertools::Itertools;
+use std::hint::black_box;
+
+fn fib_machine(n: u32) -> Machine {
+    let mut env = (0..=n)
+        .tuple_windows()
+        .map(|(i, j, k)| {
+            (
+                format!("fib_{k}"),
+                vec![
+                    Word::Custom(format!("fib_{j}")),
+                    Word::Custom(format!("fib_{i}")),
+                    Word::Core(Core::Add),
+                ],
+            )
+        })
+        .collect::<IndexMap<_, _>>();
+    env.insert("fib_0".to_string(), vec![Word::Num(1)]);
+    env.insert("fib_1".to_string(), vec![Word::Num(1)]);
+    Machine::with_env(env)
+}
+
+fn bench(c: &mut Criterion) {
+    let mut group = c.benchmark_group("Fibonacci");
+    for n in 1..30 {
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, &n| {
+            let mut m = fib_machine(n);
+            b.iter(|| m.read_eval(&black_box(format!("fib_{n}"))));
+        });
+    }
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,4 @@ mod machine;
 mod token;
 mod word;
 
-pub use crate::{core::Core, error::Error, machine::Machine};
+pub use crate::{core::Core, error::Error, machine::Machine, word::Word};

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,5 +1,6 @@
 use crate::{core::Core, error::Error, token::Token, word::Word};
 use indexmap::IndexMap;
+use lean_string::LeanString;
 use logos::Logos;
 use std::{convert::TryFrom, fmt};
 use strum::IntoEnumIterator;
@@ -7,7 +8,7 @@ use strum::IntoEnumIterator;
 /// The main data structure: a stack machine with an environment of local definitions.
 #[derive(Debug)]
 pub struct Machine {
-    env: IndexMap<String, Vec<Word>>,
+    env: IndexMap<LeanString, Vec<Word>>,
     stack: Vec<i64>,
 }
 
@@ -23,7 +24,7 @@ impl Default for Machine {
 impl Machine {
     #[must_use]
     /// Create a machine with a custom environment
-    pub fn with_env(env: IndexMap<String, Vec<Word>>) -> Self {
+    pub fn with_env(env: IndexMap<LeanString, Vec<Word>>) -> Self {
         Self {
             env,
             stack: Vec::with_capacity(64),
@@ -67,7 +68,7 @@ impl Machine {
                 if us.is_empty() {
                     return Err(Error::DefBody);
                 } else if us.iter().any(|u| u == &k) {
-                    return Err(Error::SelfRef(k));
+                    return Err(Error::SelfRef(k.to_string()));
                 }
                 let _ = self.env.insert(k, us);
                 break; // no need for `else` here
@@ -94,7 +95,7 @@ impl Machine {
 }
 
 /// Broken out because `eval_inner` is separate, too, and requires this.
-fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Result<(), Error> {
+fn check(env: &IndexMap<LeanString, Vec<Word>>, stack: &[i64], word: &Word) -> Result<(), Error> {
     let s = stack.len();
     let r = match word {
         Word::Num(_) | Word::Custom(_) => 0,
@@ -110,7 +111,7 @@ fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Resul
         Err(Error::NotNonzero(word.to_string()))
     } else if *word == Word::Core(Core::Mod) && matches!(stack[s - 2..s], [-1, i64::MIN]) {
         Err(Error::ModEdge)
-    } else if matches!(word, Word::Custom(_)) && !env.contains_key(&word.to_string()) {
+    } else if matches!(word, Word::Custom(_)) && !env.contains_key(word.unsafe_custom_inner()) {
         Err(Error::Unknown(word.to_string()))
     } else {
         Ok(())
@@ -120,7 +121,7 @@ fn check(env: &IndexMap<String, Vec<Word>>, stack: &[i64], word: &Word) -> Resul
 /// Broken out to untangle mutability concerns.
 /// Full of `stack.pop().expect(…)` because this should _only_ be called from within `Machine::eval`.
 fn eval_inner(
-    env: &IndexMap<String, Vec<Word>>,
+    env: &IndexMap<LeanString, Vec<Word>>,
     stack: &mut Vec<i64>,
     word: &Word,
 ) -> Result<(), Error> {
@@ -248,7 +249,7 @@ mod tests {
                         "def", "pop", "swap", "dup", "add", "sub", "mul", "div", "mod", "zero?", "print"
                     ]
                     .contains(&&*n))
-                    || (r.is_ok() && m.lookup(&n).is_some() && m.env.contains_key(&n) && m.to_string().contains(&n))
+                    || (r.is_ok() && m.lookup(&n).is_some() && m.env.contains_key(&LeanString::from(n.clone())) && m.to_string().contains(&n))
             );
             prop_assert!(m.stack.is_empty());
         }
@@ -259,23 +260,23 @@ mod tests {
             let s = format!("def {n} {}", ws.iter().map(std::string::ToString::to_string).collect::<Vec<_>>().join(" "));
             let mut m2 = Machine::default();
             prop_assert!(m2.read_eval(&s).is_ok());
-            prop_assert_eq!(m2.eval(&Word::Custom(n)).is_ok(), r1.is_ok());
+            prop_assert_eq!(m2.eval(&Word::Custom(n.into())).is_ok(), r1.is_ok());
         }
         #[test]
         fn fib(n in 0..16) {
             let env = {
                 let mut e = (0..=n).tuple_windows().map(|(i, j, k)| {
                     (
-                        format!("fib_{k}"),
+                        format!("fib_{k}").into(),
                         vec![
-                            Word::Custom(format!("fib_{j}")),
-                            Word::Custom(format!("fib_{i}")),
+                            Word::Custom(format!("fib_{j}").into()),
+                            Word::Custom(format!("fib_{i}").into()),
                             Word::Core(Core::Add),
                         ],
                     )
                 }).collect::<IndexMap<_, _>>();
-                e.insert("fib_0".to_string(), vec![Word::Num(1)]);
-                e.insert("fib_1".to_string(), vec![Word::Num(1)]);
+                e.insert("fib_0".into(), vec![Word::Num(1)]);
+                e.insert("fib_1".into(), vec![Word::Num(1)]);
                 e
             };
             let mut m = Machine { env, stack: Vec::new() };

--- a/src/word.rs
+++ b/src/word.rs
@@ -34,6 +34,10 @@ impl PartialEq<String> for Word {
 }
 
 impl Word {
+    /// Transform this word into a name, if possible.
+    ///
+    /// # Errors
+    /// If the word is a number or a core word.
     pub fn into_name(self) -> Result<String, Error> {
         match self {
             Self::Custom(w) => Ok(w),


### PR DESCRIPTION
I added a very silly benchmark with [`criterion`](https://bheisler.github.io/criterion.rs/book/criterion_rs.html): Fibonacci numbers—fun fact: $F_{47}$ is the largest that can fit in a `u32`.

I put together `benches/benchmark.rs` to look at how long it takes to compute the $n$-th Fibonacci number, given a bunch of preexisting definitions in its environment. This prompted a `with_env` constructor, so I could feed in those defs, plus a property test in `src/machine.rs` to make sure that the calculations worked how I thought they should.

As a result of benchmarking, I looked into [small string types](https://github.com/rosetta-rs/string-rosetta-rs) to replace our copious use of `String` for custom words. Replacing those `String`s with `lean_string::LeanString`s yielded an impressive speed up:

<img width="666" height="1286" alt="Screenshot 2025-09-08 at 12 54 45 PM" src="https://github.com/user-attachments/assets/c9139e68-12ee-457e-bf86-b86a42db1ae4" />

That said, I wouldn't look to `DRSM` for high-performance computation of the Fibonacci sequence:
![fib_lines](https://github.com/user-attachments/assets/0e8cb054-2afc-44e0-a8d5-9897aed56ca8)