### PR TITLE
`s/proptest/chaos_theory/g`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "drsm"
 description = "Dylan's Rusty Stack Machine"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2024"
 
 [dependencies]
@@ -23,9 +23,8 @@ codegen-units = 1
 panic = "abort"
 
 [dev-dependencies]
+chaos_theory = { version = "0.3.5", features = ["derive", "regex"] }
 criterion = "0.8.2"
-itertools = "0.14.0"
-proptest = "1.11.0"
 
 [lib]
 bench = false

--- a/benches/fib.rs
+++ b/benches/fib.rs
@@ -1,6 +1,5 @@
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use drsm::Machine;
-use itertools::Itertools;
 use std::hint::black_box;
 
 fn fib_machine(n: i64) -> Machine {
@@ -8,8 +7,8 @@ fn fib_machine(n: i64) -> Machine {
     let mut m = Machine::default();
     m.read_eval("def fib_0 1").expect("OK by design");
     m.read_eval("def fib_1 1").expect("OK by design");
-    (0..=n).tuple_windows().for_each(|(i, j, k)| {
-        m.read_eval(&format!("def fib_{k} fib_{j} fib_{i} add"))
+    (0..n - 1).for_each(|i| {
+        m.read_eval(&format!("def fib_{} fib_{} fib_{i} add", i + 2, i + 1))
             .expect("OK by design");
     });
     m

--- a/src/core.rs
+++ b/src/core.rs
@@ -11,6 +11,7 @@
     strum::EnumIter,
     strum::EnumString,
 )]
+#[cfg_attr(test, derive(chaos_theory::Arbitrary))]
 #[documented_fields(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum Core {
@@ -41,30 +42,16 @@ pub enum Core {
 #[cfg(test)]
 pub mod tests {
     use super::*;
-    use proptest::prelude::*;
+    use chaos_theory::check;
 
-    proptest! {
-        #[test]
-        fn roundtrip(c in core()) {
+    #[test]
+    fn roundtrip() {
+        check(|src| {
+            let c = src.any::<Core>("core");
             let s = c.to_string();
             let c2 = s.parse::<Core>();
-            prop_assert!(c2.is_ok());
-            prop_assert_eq!(c2.expect("is_ok"), c);
-        }
-    }
-
-    pub fn core() -> impl Strategy<Value = Core> {
-        prop_oneof![
-            Just(Core::Drop),
-            Just(Core::Swap),
-            Just(Core::Dup),
-            Just(Core::Add),
-            Just(Core::Sub),
-            Just(Core::Mul),
-            Just(Core::Div),
-            Just(Core::Mod),
-            Just(Core::Zero),
-            Just(Core::Print),
-        ]
+            assert!(c2.is_ok());
+            assert_eq!(c2.expect("is_ok"), c);
+        });
     }
 }

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -1,6 +1,6 @@
 use crate::{core::Core, error::Error, token::Token, word::Word};
-use indexmap::IndexMap;
 use lean_string::LeanString;
+use indexmap::IndexMap;
 use logos::Logos;
 use std::{convert::TryFrom, fmt};
 use strum::IntoEnumIterator;
@@ -78,13 +78,17 @@ impl Machine {
     }
     /// `check` the input, then run it through `eval_inner`.
     fn eval(&mut self, word: &Word) -> Result<(), Error> {
-        check(&self.env, &self.stack, word)?;
+        check_word(&self.env, &self.stack, word)?;
         eval_inner(&self.env, &mut self.stack, word)
     }
 }
 
 /// Broken out because `eval_inner` is separate, too, and requires this.
-fn check(env: &IndexMap<LeanString, Vec<Word>>, stack: &[i64], word: &Word) -> Result<(), Error> {
+fn check_word(
+    env: &IndexMap<LeanString, Vec<Word>>,
+    stack: &[i64],
+    word: &Word,
+) -> Result<(), Error> {
     let s = stack.len();
     let r = match word {
         Word::Num(_) | Word::Custom(_) => 0,
@@ -164,7 +168,7 @@ fn eval_inner(
         Word::Num(n) => stack.push(*n),
         Word::Custom(c) => {
             for w in &env[c] {
-                check(env, stack, w)?;
+                check_word(env, stack, w)?;
                 eval_inner(env, stack, w)?;
             }
         }
@@ -174,9 +178,8 @@ fn eval_inner(
 
 #[cfg(test)]
 mod tests {
-    use super::{super::word::tests::word, *};
-    use itertools::Itertools;
-    use proptest::prelude::*;
+    use super::*;
+    use chaos_theory::{check, make};
     use std::string::ToString;
 
     #[test]
@@ -203,9 +206,8 @@ mod tests {
             Err(Error::Bad)
         } else {
             let mut m = Machine::default();
-            (0..=n)
-                .tuple_windows()
-                .map(|(i, j, k)| m.read_eval(&format!("def fib_{k} fib_{j} fib_{i} add")))
+            (0..n - 1)
+                .map(|i| m.read_eval(&format!("def fib_{} fib_{} fib_{i} add", i + 2, i + 1)))
                 .collect::<Result<Vec<_>, _>>()?;
             m.read_eval("def fib_1 1")?;
             m.read_eval("def fib_0 1")?;
@@ -214,44 +216,64 @@ mod tests {
         }
     }
 
-    proptest! {
-        #[test]
-        fn pushing_extends_stack(ns in prop::collection::vec(any::<i64>(), 1..64)) {
+    #[test]
+    fn pushing_extends_stack() {
+        check(|src| {
+            let ns = src.any_of("ns", make::vec_with_size(make::arbitrary(), 1..64));
             let mut m = Machine::default();
             let mut old = m.to_string().len();
             for n in ns {
-                prop_assert!(m.eval(&Word::Num(n)).is_ok());
+                assert!(m.eval(&Word::Num(n)).is_ok());
                 let new = m.to_string().len();
-                prop_assert_eq!(new - old, format!(" {n}").len());
+                assert_eq!(new - old, format!(" {n}").len());
                 old = new;
             }
-        }
-        #[test]
-        fn check_implies_eval(ws in prop::collection::vec(word(), 0..64)) {
+        });
+    }
+
+    #[test]
+    fn check_implies_eval() {
+        check(|src| {
+            let ws = src.any_of("ws", make::vec_with_size(make::arbitrary(), 0..64));
             let mut m = Machine::default();
             for w in ws {
-                prop_assert_eq!(check(&m.env, &m.stack, &w).is_ok(), m.eval(&w).is_ok());
+                assert_eq!(check_word(&m.env, &m.stack, &w).is_ok(), m.eval(&w).is_ok());
             }
-        }
-        #[test]
-        fn check_implies_read_eval(ws in prop::collection::vec(word(), 0..64)) {
+        });
+    }
+
+    #[test]
+    fn check_implies_read_eval() {
+        check(|src| {
+            let ws = src.any_of("ws", make::vec_with_size(make::arbitrary(), 0..64));
             let mut m = Machine::default();
             for w in ws {
-                prop_assert_eq!(check(&m.env, &m.stack, &w).is_ok(), m.read_eval(&w.to_string()).is_ok());
+                assert_eq!(
+                    check_word(&m.env, &m.stack, &w).is_ok(),
+                    m.read_eval(&w.to_string()).is_ok()
+                );
             }
-        }
-        #[test]
-        fn def_adds_to_env(ws in prop::collection::vec(r"\S+", 0..64), n in r"custom_name_\S+") {
+        });
+    }
+
+    #[test]
+    fn def_adds_to_env() {
+        check(|src| {
+            let ws = src.any_of(
+                "ws",
+                make::vec_with_size(make::string_matching(r"custom_name_\S+", true), 0..64),
+            );
+            let n = src.any_of("n", make::string_matching(r"custom_name_\S+", true));
             let mut m = Machine::default();
             let d = ws.join(" ");
-            let s = format!("def {n} {d}");
-            let r = m.read_eval(&s);
-            prop_assert!(
+            let r = m.read_eval(&format!("def {n} {d}"));
+            assert!(
                 (ws.is_empty()
                     || ws.contains(&n)
                     || n.parse::<i64>().is_ok()
                     || [
-                        "def", "pop", "swap", "dup", "add", "sub", "mul", "div", "mod", "zero?", "print",
+                        "def", "pop", "swap", "dup", "add", "sub", "mul", "div", "mod", "zero?",
+                        "print",
                     ]
                     .contains(&&*n))
                     || (r.is_ok()
@@ -259,12 +281,20 @@ mod tests {
                         && m.env.contains_key(&LeanString::from(n.clone()))
                         && m.to_string().contains(&n))
             );
-            prop_assert!(m.stack.is_empty());
-        }
-        #[test]
-        fn custom_ok(ws in prop::collection::vec(word(), 1..64), n in r"custom_word_\S+") {
+            assert!(m.stack.is_empty());
+        });
+    }
+
+    #[test]
+    fn custom_ok() {
+        check(|src| {
+            let ws = src.any_of("ws", make::vec_with_size(make::arbitrary(), 1..64));
+            let n = src.any_of("n", make::string_matching(r"custom_name_\S+", true));
             let mut m1 = Machine::default();
-            let r1 = ws.iter().map(|w| m1.eval(w)).collect::<Result<Vec<()>, _>>();
+            let r1 = ws
+                .iter()
+                .map(|w| m1.eval(w))
+                .collect::<Result<Vec<()>, _>>();
             let s = format!(
                 "def {n} {}",
                 ws.iter()
@@ -273,11 +303,15 @@ mod tests {
                     .join(" ")
             );
             let mut m2 = Machine::default();
-            prop_assert!(m2.read_eval(&s).is_ok());
-            prop_assert_eq!(m2.eval(&Word::Custom(n.into())).is_ok(), r1.is_ok());
-        }
-        #[test]
-        fn fib(n in 0..16i64) {
+            assert!(m2.read_eval(&s).is_ok());
+            assert_eq!(m2.eval(&Word::Custom(n.into())).is_ok(), r1.is_ok());
+        });
+    }
+
+    #[test]
+    fn fib() {
+        check(|src| {
+            let n = src.any_of("n", make::int_in_range(0..16));
             let (mut a, mut b) = (1, 1);
             for _ in 1..n {
                 let t = a + b;
@@ -285,8 +319,8 @@ mod tests {
                 b = t;
             }
             let r = fib_machine(n);
-            prop_assert!(r.is_ok());
-            prop_assert_eq!(r.expect("is_ok"), b);
-        }
+            assert!(r.is_ok());
+            assert_eq!(r.expect("is_ok"), b);
+        });
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -3,6 +3,7 @@ use logos::Logos;
 
 /// Tokens are lexed from input strings.
 #[derive(Logos, Debug, PartialEq, Eq, Clone, strum::Display)]
+#[cfg_attr(test, derive(chaos_theory::Arbitrary))]
 #[logos(skip r"\s", error = crate::Error)]
 pub enum Token<'source> {
     /// Define a new word.
@@ -20,39 +21,33 @@ pub enum Token<'source> {
     /// An integer in hexadecimal notation.
     #[regex(r"#[[:xdigit:]]+", |lex| i64::from_str_radix(&lex.slice()[1..], 16))]
     #[strum(serialize = "#{0:x}")]
-    Hex(i64),
+    Hex(#[cfg_attr(test, chaos_theory(generator = chaos_theory::make::int_in_range(0..)))] i64),
     /// A (possibly unknown) custom token.
     #[regex(r"\S+", priority = 0)]
     #[strum(serialize = "{0}")]
-    Custom(&'source str),
+    Custom(
+        #[cfg_attr(test, chaos_theory(generator = chaos_theory::make::just("custom_token")))]
+        &'source str,
+    ),
 }
 
 #[cfg(test)]
 pub mod tests {
-    use super::{super::core::tests::core, *};
+    use super::*;
+    use chaos_theory::check;
     use logos::Logos;
-    use proptest::prelude::*;
 
-    proptest! {
-        #[test]
-        fn roundtrip(t in token()) {
+    #[test]
+    fn roundtrip() {
+        check(|src| {
+            let t = src.any::<Token>("token");
             let s = t.to_string();
             let ts = Token::lexer(&s).collect::<Result<Vec<_>, _>>();
-            prop_assert!(ts.is_ok());
+            assert!(ts.is_ok());
             let mut ts = ts.expect("is_ok");
-            prop_assert_eq!(ts.len(), 1);
+            assert_eq!(ts.len(), 1);
             let t2 = ts.pop().expect("len == 1");
-            prop_assert_eq!(t2, t);
-        }
-    }
-
-    pub fn token() -> impl Strategy<Value = Token<'static>> {
-        prop_oneof![
-            Just(Token::Def),
-            core().prop_map(Token::Core),
-            any::<i64>().prop_map(Token::Num),
-            (0..i64::MAX).prop_map(Token::Hex),
-            Just("custom_token").prop_map(Token::Custom),
-        ]
+            assert_eq!(t2, t);
+        });
     }
 }

--- a/src/word.rs
+++ b/src/word.rs
@@ -4,6 +4,7 @@ use std::convert::TryFrom;
 
 /// The words upon which our stack machine works.
 #[derive(Debug, PartialEq, Eq, Clone, strum::Display)]
+#[cfg_attr(test, derive(chaos_theory::Arbitrary))]
 pub enum Word {
     /// A core word,
     #[strum(serialize = "{0}")]
@@ -13,7 +14,18 @@ pub enum Word {
     Num(i64),
     /// A custom word.
     #[strum(serialize = "{0}")]
-    Custom(LeanString),
+    Custom(#[cfg_attr(test, chaos_theory(generator = custom()))] LeanString),
+}
+
+#[cfg(test)]
+fn custom() -> impl chaos_theory::Generator<Item = LeanString> {
+    chaos_theory::make::from_fn(|src| {
+        let s = src.any_of(
+            "custom word",
+            chaos_theory::make::string_matching(r"custom_[a-zA-Z]+", true),
+        );
+        LeanString::from(&s)
+    })
 }
 
 impl TryFrom<Token<'_>> for Word {
@@ -52,7 +64,7 @@ impl Word {
             Self::Core(_) => Err(Error::CoreNotName(self.to_string())),
         }
     }
-    /// Unsafely grab the inner lean string of this custom word.
+    /// Unsafely grab the inner `LeanString` of this custom word.
     ///
     /// # Panics
     /// If this isn't a custom word.
@@ -66,51 +78,58 @@ impl Word {
 
 #[cfg(test)]
 pub mod tests {
-    use super::{
-        super::{core::tests::core, token::tests::token},
-        *,
-    };
+    use super::*;
+    use chaos_theory::check;
     use logos::Logos;
-    use proptest::prelude::*;
 
-    proptest! {
-        #[test]
-        fn from_token(t in token()) {
+    #[test]
+    fn from_token() {
+        check(|src| {
+            let t = src.any::<Token>("token");
             let w = Word::try_from(t.clone());
-            prop_assert_eq!(w.is_ok(), t != Token::Def);
-        }
-        #[test]
-        fn self_eq(w in word()) {
-            prop_assert_eq!(w.clone(), w);
-        }
-        #[test]
-        #[allow(clippy::cmp_owned)]
-        fn str_eq(w in word(), s in r"\S+") {
-            prop_assert_eq!(w == s, w.to_string() == s);
-        }
-        #[test]
-        fn roundtrip(w in word()) {
-            let s = w.to_string();
-            let ts = Token::lexer(&s).collect::<Result<Vec<Token>, _>>();
-            prop_assert!(ts.is_ok());
-            let mut ts = ts.expect("is_ok");
-            prop_assert_eq!(ts.len(), 1);
-            let w2 = Word::try_from(ts.pop().expect("len == 1"));
-            prop_assert!(w2.is_ok());
-            prop_assert_eq!(w2.expect("is_ok"), w);
-        }
-        #[test]
-        fn into_name(w in word()) {
-            let n = w.clone().into_name();
-            prop_assert_eq!(n.is_ok(), w == Word::Custom(n.unwrap_or_default()));
-        }
+            assert_eq!(w.is_ok(), t != Token::Def);
+        });
     }
 
-    pub fn word() -> impl Strategy<Value = Word> {
-        prop_oneof![
-            core().prop_map(Word::Core),
-            any::<i64>().prop_map(Word::Num),
-            r"custom_[a-zA-Z]+".prop_map(|s| Word::Custom(s.into()))
-        ]
+    #[test]
+    fn self_eq() {
+        check(|src| {
+            let w = src.any::<Word>("word");
+            assert_eq!(w.clone(), w);
+        });
+    }
+
+    #[test]
+    #[allow(clippy::cmp_owned)]
+    fn str_eq() {
+        check(|src| {
+            let w = src.any::<Word>("word");
+            let s = src.any_of("string", chaos_theory::make::string_matching(r"\S+", true));
+            assert_eq!(w == s, w.to_string() == s);
+        });
+    }
+
+    #[test]
+    fn roundtrip() {
+        check(|src| {
+            let w = src.any::<Word>("word");
+            let s = w.to_string();
+            let ts = Token::lexer(&s).collect::<Result<Vec<Token>, _>>();
+            assert!(ts.is_ok());
+            let mut ts = ts.expect("is_ok");
+            assert_eq!(ts.len(), 1);
+            let w2 = Word::try_from(ts.pop().expect("len == 1"));
+            assert!(w2.is_ok());
+            assert_eq!(w2.expect("is_ok"), w);
+        });
+    }
+
+    #[test]
+    fn into_name() {
+        check(|src| {
+            let w = src.any::<Word>("word");
+            let n = w.clone().into_name();
+            assert_eq!(n.is_ok(), w == Word::Custom(n.unwrap_or_default()));
+        });
     }
 }


### PR DESCRIPTION
Our property tests are now faster & don't require as much macro wizardry.

I also removed the `itertools` dev dependency, we don't need a whole thing just for `tuple_windows` in the Fibonacci test/benchmark .